### PR TITLE
changed one paper category and added link

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Charlie Hou, Mingxun Zhou, Yan Ji and Phil Daian, Florian Tramèr, Giulia Fanti,
 
 [Consensus][Partitioning Ethereum without Eclipsing It](). Hwanjo Heo and Seungwon Woo, Tae Ung Yoon, Min Suk Kang and Seungwon Shin. NDSS '23.  
 
-[Consensus][Double and Nothing: Understanding and Detecting Cryptocurrency Giveaway Scams](). Xigao Li, Anurag Yepuri, and Nick Nikiforakis. NDSS '23.   
+[Security][Double and Nothing: Understanding and Detecting Cryptocurrency Giveaway Scams](https://double-and-nothing.github.io/). Xigao Li, Anurag Yepuri, and Nick Nikiforakis. NDSS '23.   
 
 [Payment Channel][He-HTLC: Revisiting Incentives in HTLC]() Sarisht Wadhwa and Jannis Stoeter, Fan Zhang, Kartik Nayak. NDSS '23.   
 


### PR DESCRIPTION
Thanks for listing our paper (Double and Nothing: Understanding and Detecting Cryptocurrency Giveaway Scams) into the repository! I would like to make a few modifications to the entry.

- A correction to the paper category, as the paper discuss the security issue in cryptocurrency instead of consensus.
- I also included a Github Page link to paper and dataset for better reference.

Thanks again!
Xigao